### PR TITLE
Adds run configuration environment variables customization support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,10 @@ dependencies {
     testCompile name: 'PsiViewer'
 }
 
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         apiVersion = '1.3'

--- a/src/main/java/com/intellij/plugin/powershell/ide/run/PowerShellRunSettingsEditor.form
+++ b/src/main/java/com/intellij/plugin/powershell/ide/run/PowerShellRunSettingsEditor.form
@@ -47,11 +47,6 @@
         </constraints>
         <properties/>
       </component>
-      <vspacer id="8c5b9">
-        <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </vspacer>
       <component id="1188d" class="javax.swing.JLabel">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -75,6 +70,27 @@
         </constraints>
         <properties/>
       </component>
+      <component id="636b7" class="com.intellij.execution.configuration.EnvironmentVariablesTextFieldWithBrowseButton" binding="environmentVariablesTextFieldWithBrowseButton">
+        <constraints>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="2e942" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Environment variables:"/>
+        </properties>
+      </component>
+      <vspacer id="8c5b9">
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/src/main/java/com/intellij/plugin/powershell/ide/run/PowerShellRunSettingsEditor.java
+++ b/src/main/java/com/intellij/plugin/powershell/ide/run/PowerShellRunSettingsEditor.java
@@ -1,5 +1,6 @@
 package com.intellij.plugin.powershell.ide.run;
 
+import com.intellij.execution.configuration.EnvironmentVariablesTextFieldWithBrowseButton;
 import com.intellij.ide.util.BrowseFilesListener;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.fileChooser.FileChooserFactory;
@@ -24,6 +25,7 @@ public class PowerShellRunSettingsEditor extends SettingsEditor<PowerShellRunCon
   private JTextField commandOptionsTextField;
   private JBTextField workingDirectoryTextField;
   private TextFieldWithBrowseButton workingDirectoryTextFieldWithBrowseBtn;
+  private EnvironmentVariablesTextFieldWithBrowseButton environmentVariablesTextFieldWithBrowseButton;
 
   public PowerShellRunSettingsEditor(Project project, PowerShellRunConfiguration runConfiguration) {
     this.runConfiguration = runConfiguration;

--- a/src/main/java/com/intellij/plugin/powershell/ide/run/PowerShellRunSettingsEditor.java
+++ b/src/main/java/com/intellij/plugin/powershell/ide/run/PowerShellRunSettingsEditor.java
@@ -1,5 +1,6 @@
 package com.intellij.plugin.powershell.ide.run;
 
+import com.intellij.execution.configuration.EnvironmentVariablesData;
 import com.intellij.execution.configuration.EnvironmentVariablesTextFieldWithBrowseButton;
 import com.intellij.ide.util.BrowseFilesListener;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
@@ -39,6 +40,8 @@ public class PowerShellRunSettingsEditor extends SettingsEditor<PowerShellRunCon
     String configName = configuration.getName();
     String scriptPath = configuration.getScriptPath();
     String workingDir = configuration.getWorkingDirectory();
+    EnvironmentVariablesData envVars = configuration.getEnvironmentVariables();
+
     if (workingDir.equals(PSExecutionUtilKt.getDefaultWorkingDirectory())) {
       workingDirectoryTextField.getEmptyText().setText(workingDir);
     } else {
@@ -63,6 +66,8 @@ public class PowerShellRunSettingsEditor extends SettingsEditor<PowerShellRunCon
     if (!StringUtil.isEmpty(commandOptions)) {
       commandOptionsTextField.setText(commandOptions);
     }
+
+    environmentVariablesTextFieldWithBrowseButton.setData(envVars);
   }
 
   @Override
@@ -71,6 +76,7 @@ public class PowerShellRunSettingsEditor extends SettingsEditor<PowerShellRunCon
     configuration.setWorkingDirectory(workingDirectoryTextFieldWithBrowseBtn.getText().trim());
     configuration.setScriptParameters(parametersTextField.getText().trim());
     configuration.setCommandOptions(commandOptionsTextField.getText().trim());
+    configuration.setEnvironmentVariables(environmentVariablesTextFieldWithBrowseButton.getData());
   }
 
   @NotNull

--- a/src/main/kotlin/com/intellij/plugin/powershell/ide/run/PowerShellRunConfiguration.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/ide/run/PowerShellRunConfiguration.kt
@@ -2,6 +2,7 @@ package com.intellij.plugin.powershell.ide.run
 
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.Executor
+import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.LocatableConfigurationBase
 import com.intellij.execution.configurations.RunConfiguration
@@ -27,6 +28,7 @@ class PowerShellRunConfiguration(project: Project, configurationFactory: Configu
     get() = if (StringUtil.isEmptyOrSpaces(field)) getDefaultWorkingDirectory() else field
   var scriptParameters: String = ""
   private var commandOptions: String? = null
+  var environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
 
   override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> = PowerShellRunSettingsEditor(project, this)
 
@@ -53,6 +55,7 @@ class PowerShellRunConfiguration(project: Project, configurationFactory: Configu
     if (!StringUtil.isEmpty(workingDirectory)) {
       this.workingDirectory = workingDirectory
     }
+    environmentVariables = EnvironmentVariablesData.readExternal(element)
   }
 
   @Throws(WriteExternalException::class)
@@ -70,6 +73,7 @@ class PowerShellRunConfiguration(project: Project, configurationFactory: Configu
     if (!StringUtil.isEmpty(workingDirectory)) {
       element.setAttribute(WORKING_DIRECTORY, workingDirectory)
     }
+    environmentVariables.writeExternal(element)
   }
 
    fun getCommandOptions(): String = StringUtil.notNullize(commandOptions)

--- a/src/main/kotlin/com/intellij/plugin/powershell/ide/run/PowerShellScriptCommandLineState.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/ide/run/PowerShellScriptCommandLineState.kt
@@ -1,5 +1,6 @@
 package com.intellij.plugin.powershell.ide.run
 
+import com.esotericsoftware.minlog.Log
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.configurations.GeneralCommandLine
@@ -22,8 +23,10 @@ class PowerShellScriptCommandLineState(private val runConfiguration: PowerShellR
       val command = buildCommand(runConfiguration.scriptPath, runConfiguration.getCommandOptions(), runConfiguration.scriptParameters)
       val commandLine = GeneralCommandLine(command)
       commandLine.setWorkDirectory(runConfiguration.workingDirectory)
-      LOG.debug("Command line: " + command.toString())
-      LOG.debug("Environment: " + commandLine.parentEnvironment.toString())
+      runConfiguration.environmentVariables.configureCommandLine(commandLine, true)
+      LOG.debug("Command line: $command")
+      LOG.debug("Environment: " + commandLine.environment.toString())
+      LOG.debug("Effective Environment: " + commandLine.effectiveEnvironment.toString())
       return PowerShellProcessHandler(commandLine)
     } catch (e: PowerShellNotInstalled) {
       LOG.warn("Can not start PowerShell: ${e.message}")

--- a/src/main/kotlin/com/intellij/plugin/powershell/ide/run/PowerShellScriptCommandLineState.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/ide/run/PowerShellScriptCommandLineState.kt
@@ -1,6 +1,5 @@
 package com.intellij.plugin.powershell.ide.run
 
-import com.esotericsoftware.minlog.Log
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.configurations.GeneralCommandLine


### PR DESCRIPTION
Closes #49.

Also added Java compilation encoding to be explicitly set to UTF-8 as Windows defaults to cp1252 on build, and some tests fail.