### PR TITLE
fix: add macOS PowerShell executable path...

### DIFF
--- a/src/main/kotlin/com/intellij/plugin/powershell/ide/run/PSExecutionUtil.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/ide/run/PSExecutionUtil.kt
@@ -10,7 +10,8 @@ import com.intellij.util.EnvironmentUtil
 @Throws(PowerShellNotInstalled::class)
 fun findPsExecutable(): String {
   val osPath = EnvironmentUtil.getValue("PATH") ?: throw PowerShellNotInstalled("Can not get OS PATH")
-  val paths = osPath.split(if (SystemInfo.isWindows) ";" else ":")
+  var paths = osPath.split(if (SystemInfo.isWindows) ";" else ":")
+  if (SystemInfo.isMac) paths = paths.plusElement("/usr/local/bin")
   val suf = if (SystemInfo.isWindows) ".exe" else ""
   val exec = arrayListOf("powershell$suf", "pwsh$suf")
   paths.forEach { p ->

--- a/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/PSLanguageHostUtils.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/PSLanguageHostUtils.kt
@@ -123,7 +123,7 @@ fun readPowerShellVersion(exePath: String, indicator: ProgressIndicator? = null)
     try {
       process = GeneralCommandLine(arrayListOf(exePath, "-command", commandString)).createProcess()
       for (i in 1..6) {
-        process.waitFor(500L, TimeUnit.MILLISECONDS)
+        process.waitFor(2000L, TimeUnit.MILLISECONDS)
         indicator?.checkCanceled()
       }
       if (process.isAlive) {


### PR DESCRIPTION
and wait more time to read PowerShell version
close #64

In L126, I update hardcoded time out milliseconds from 500 to 2000, based on my own PowerShell loading time.