### PR TITLE
Update PowerShell.bnf for chain pipeline operators

### DIFF
--- a/src/main/resources/PowerShell.bnf
+++ b/src/main/resources/PowerShell.bnf
@@ -125,7 +125,7 @@
     BRACED_VAR_START='${'
 
     EQ='='
-    PIPE='|'
+    PIPE='regexp:(\|\||\||&&)'
     AMP='&'
     PP='++'
     MM='--'


### PR DESCRIPTION
Adding chain pipeline operators (|| and &&) which should be the same as a regular pipeline for the parser

Ressource: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pipeline_chain_operators?view=powershell-7.2