### PR TITLE
Changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Read the changelog
+        uses: ForNeVeR/ChangelogAutomation.action@v1
+        with:
+          input: ./CHANGELOG.md
+          output: ./changelog-section.md
+
+      - name: Upload the changelog
+        uses: actions/upload-artifact@v2
+        with:
+          name: changelog-section.md
+          path: ./changelog-section.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - 'v*'
   pull_request:
     branches:
-      - main
+      - master
   schedule:
     - cron: '0 0 * * 0' # Every Sunday
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ Same as **2.0.0**, but compatible with IntelliJ 2018.2+.
 - [#11 (BitBucket)](https://bitbucket.org/adernov/powershell/issues/11): `using` keyword not being recognized
 
 ### Added
-- More pre-defined [Live Template](<a href="https://www.jetbrains.com/help/idea/live-templates.html) snippets
+- More pre-defined [Live Template](https://www.jetbrains.com/help/idea/live-templates.html) snippets
 
 ### Changed
 - Use `-File` parameter to specify the script file to run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,173 @@
+Changelog
+=========
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased] (2.1.0)
+### Changed
+- The minimal supported IntelliJ version is now 2023.2
+- [#45](https://github.com/ant-druha/intellij-powershell/pull/45): Upgrade PSScriptAnalyzer from 1.17.1 to 1.19.0, thanks to @bergmeister
+- [#75](https://github.com/ant-druha/intellij-powershell/pull/75): Add indents for array elements when formatting, thanks to @VladRassokhin
+- [#90](https://github.com/ant-druha/intellij-powershell/pull/90): Allow for more user interaction with the run configuration in terminal (use PTY when available), thanks to @ZhengKeli
+- [#89](https://github.com/ant-druha/intellij-powershell/pull/89): Allow entering the executables from `PATH` in the plugin settings, thanks to @ZhengKeli
+
+## [2.0.10] - 2022-02-25
+### Fixed
+- [#76](https://github.com/ant-druha/intellij-powershell/issues/76): Exception thrown when plugin is enabled but no PowerShell is found
+
+## [2.0.9] - 2021-11-30
+### Fixed
+- Properly mark the plugin as compatible with IntelliJ 2021.3+
+
+## [2.0.8] - 2021-11-19
+### Changed
+- The minimal supported IntelliJ version is now 2021.3
+
+### Added
+- [#63](https://github.com/ant-druha/intellij-powershell/issues/63): support Path Macros for the run configuration
+
+## [2.0.7] - 2021-05-25
+### Added
+- Ability to set PowerShell version globally and for Run Configuration
+- Run Configuration: ability to specify environment variables
+- macOS ARM support
+
+## [2.0.6] - 2021-03-13
+### Changed
+- The minimal supported IntelliJ version is now 2021.1
+
+### Fixed
+- [#40](https://github.com/ant-druha/intellij-powershell/issues/40): Run configuration keeps getting renamed when opening or editing, thanks to @Dimi1010
+
+## [2.0.5] - 2020-04-14
+### Added
+- [#48](https://github.com/ant-druha/intellij-powershell/pull/48) Adds simplest code folding: for code blocks, arrays, thanks to @VladRassokhin
+
+## [2.0.4] - 2019-11-22
+### Fixed
+- [#38](https://github.com/ant-druha/intellij-powershell/issues/38): UnsupportedClassVersionError running 2019.3 under 1.8 JDK
+
+## [2.0.3] - 2019-11-03
+### Removed
+- [#33](https://github.com/ant-druha/intellij-powershell/issues/33): Get rid of implicit dependency on Java plugin
+
+### Changed
+- Platform API maintenance update
+
+### Fixed
+- PSES startup script path wrong for standalone unpacked installation
+- Stack overflow in RenamePsiElementProcessor.findReferences
+
+## [2.0.2] - 2019-05-23
+### Changed
+- The minimal supported IntelliJ version is now 2019.2 compatibility
+
+### Fixed
+- [#24](https://github.com/ant-druha/intellij-powershell/issues/24): Parenthesized expression parsing error
+
+## [2.0.1] - 2019-01-17
+### Fixed
+- [#10](https://github.com/ant-druha/PowerShell/issues/10): Script Arguments not working as expected
+- [#12](https://github.com/ant-druha/PowerShell/issues/12): Memory (project) leak in plugin, thanks to @VladRassokhin
+
+## [2.0.0-IJ2018.2.X] - 2018-12-07
+Same as **2.0.0**, but compatible with IntelliJ 2018.2+.
+
+## [2.0.0] - 2018-12-07
+### Added
+- [#9](https://github.com/ant-druha/PowerShell/issues/9): PowerShell ScriptAnalyzer support in IDE Editor
+- [#3](https://github.com/ant-druha/PowerShell/issues/3) Run/Debug configuration: ability to set working directory
+
+### Changed
+- [#6](https://github.com/ant-druha/PowerShell/issues/6): Update PowerShell Language server version
+
+### Fixed
+- [#5](https://github.com/ant-druha/PowerShell/issues/5): Reformat code Error
+- [#2](https://github.com/ant-druha/PowerShell/issues/2): NullPointerException during normal IDE operation
+- [#1](https://github.com/ant-druha/PowerShell/issues/1): Exception on PyCharm launch
+
+## [1.1.1] - 2018-06-21
+### Added
+- [#22 (BitBucket)](https://bitbucket.org/adernov/powershell/issues/22): Integrated PowerShell Console
+- [#18 (BitBucket)](https://bitbucket.org/adernov/powershell/issues/18): Remote files editing with 'psedit' command in PowerShell console
+
+## [1.1.0] - 2018-05-15
+### Added
+- Language injections in interpolated strings
+
+### Fixed
+- [#19 (BitBucket)](https://bitbucket.org/adernov/powershell/issues/19): Source formatting does not omit "@ at the beginning of line
+- [#20 (BitBucket)](https://bitbucket.org/adernov/powershell/issues/20): Handle drive letters in unc path
+- [#21 (BitBucket)](https://bitbucket.org/adernov/powershell/issues/21): `NoClassDefFoundError` if IntelliLang plugin is not installed
+
+## [1.0.2] - 2018-01-31
+### Fixed
+- [#11 (BitBucket)](https://bitbucket.org/adernov/powershell/issues/11): `using` keyword not being recognized
+
+### Added
+- More pre-defined [Live Template](<a href="https://www.jetbrains.com/help/idea/live-templates.html) snippets
+
+### Changed
+- Use `-File` parameter to specify the script file to run
+
+## [1.0.1] - 2018-01-25
+### Fixed
+- [#8 (BitBucket)](https://bitbucket.org/adernov/powershell/issues/8): Exception shown on LSP communication failure
+- [#9 (BitBucket)](https://bitbucket.org/adernov/powershell/issues/9): Language server fails to start if path to startup script contains spaces
+
+## [1.0.0] - 2018-01-22
+### Added
+- Language Server Protocol support. Plugin now bundles [PowerShellEditorServices module](https://github.com/PowerShell/PowerShellEditorServices) (same as VSCode) to provide Editor assistance. Supported requests:
+  - `textDocument/didOpen` (File opened in editor)
+  - `textDocument/didClose` (File closed in editor)
+  - `textDocument/didChange` (Editor document text changes)
+  - `textDocument/completion` (Editor Auto completion)
+
+## [0.0.3] - 2018-01-16
+### Added
+- [#3 (BitBucket)](https://bitbucket.org/adernov/powershell/issues/3): Support PowerShell Scopes like Global or Local for functions
+- [#5 (BitBucket)](https://bitbucket.org/adernov/powershell/issues/5): Support more PowerShell file extensions
+
+### Fixed
+- [#7 (BitBucket)](https://bitbucket.org/adernov/powershell/issues/7): `StackOverflowError` on resolving variable that has no definition
+
+## [0.0.2] - 2017-12-25
+### Changed
+Enhanced completion:
+- resolve and completion of declared in script type members (methods, properties, constructors);
+- completion for different contexts (references, types, properties).
+
+## [0.0.1] - 2017-12-06
+Initial editor intellisense support:
+- syntax highlighting;
+- variables and declared types reference resolve and find usages;
+- reference and keyword completion;
+- rename refactoring;
+- structure view;
+- colors and fonts;
+- code style;
+- live templates;
+- run configuration.
+
+[0.0.1]: https://github.com/ant-druha/intellij-powershell/releases/tag/v0.0.1
+[0.0.2]: https://github.com/ant-druha/intellij-powershell/compare/v0.0.1...v0.0.2
+[0.0.3]: https://github.com/ant-druha/intellij-powershell/compare/v0.0.2...v0.0.3
+[1.0.0]: https://github.com/ant-druha/intellij-powershell/compare/v0.0.3...v1.0.0
+[1.0.1]: https://github.com/ant-druha/intellij-powershell/compare/v1.0.0...v1.0.1
+[1.0.2]: https://github.com/ant-druha/intellij-powershell/compare/v1.0.1...v1.0.2
+[1.1.0]: https://github.com/ant-druha/intellij-powershell/compare/v1.0.2...v1.1.0
+[1.1.1]: https://github.com/ant-druha/intellij-powershell/compare/v1.1.0...v1.1.1
+[2.0.0]: https://github.com/ant-druha/intellij-powershell/compare/v1.1.1...v2.0.0
+[2.0.0-IJ2018.2.X]: https://github.com/ant-druha/intellij-powershell/compare/v2.0.0...v2.0.0-IJ2018.2.X
+[2.0.1]: https://github.com/ant-druha/intellij-powershell/compare/v2.0.0...v2.0.1
+[2.0.2]: https://github.com/ant-druha/intellij-powershell/compare/v2.0.1...v2.0.2
+[2.0.3]: https://github.com/ant-druha/intellij-powershell/compare/v2.0.2...v2.0.3
+[2.0.4]: https://github.com/ant-druha/intellij-powershell/compare/v2.0.3...v2.0.4
+[2.0.5]: https://github.com/ant-druha/intellij-powershell/compare/v2.0.4...v2.0.5
+[2.0.6]: https://github.com/ant-druha/intellij-powershell/compare/v2.0.5...v2.0.6
+[2.0.7]: https://github.com/ant-druha/intellij-powershell/compare/v2.0.6...v2.0.7
+[2.0.8]: https://github.com/ant-druha/intellij-powershell/compare/v2.0.7...v2.0.8
+[2.0.9]: https://github.com/ant-druha/intellij-powershell/compare/v2.0.8...v2.0.9
+[2.0.10]: https://github.com/ant-druha/intellij-powershell/compare/v2.0.9...v2.0.10
+[Unreleased]: https://github.com/ant-druha/intellij-powershell/compare/v2.0.10...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - [#40](https://github.com/ant-druha/intellij-powershell/issues/40): Run configuration keeps getting renamed when opening or editing, thanks to @Dimi1010
 
-## [2.0.5] - 2020-04-14
+## [2.0.5] - 2020-08-14
 ### Added
 - [#48](https://github.com/ant-druha/intellij-powershell/pull/48) Adds simplest code folding: for code blocks, arrays, thanks to @VladRassokhin
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ Install the plugin [from IDE](https://www.jetbrains.com/help/idea/managing-plugi
 
 Documentation
 -------------
-- [License (Apache 2)][docs.license]
+- [Changelog][docs.changelog]
 - [Contributor Guide][docs.contributing]
+- [License (Apache 2)][docs.license]
 
 [badge-plugins]: https://img.shields.io/jetbrains/plugin/v/10249?label=powershell
+[docs.changelog]: ./CHANGELOG.md
 [docs.contributing]: ./CONTRIBUTING.md
 [docs.license]: ./LICENSE
 [plugin-repository]: https://plugins.jetbrains.com/plugin/10249-powershell

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
     id("java")
+    id("org.jetbrains.changelog") version "2.2.0"
     id("org.jetbrains.intellij") version "1.15.0"
     id("org.jetbrains.kotlin.jvm") version "1.9.0"
 }
 
 intellij {
     type.set("IC")
-    // https://www.jetbrains.com/intellij-repository/releases
     version.set("2023.2")
     plugins.set(listOf("org.intellij.intelliLang", "terminal"))
     pluginName.set("PowerShell")
@@ -61,4 +61,19 @@ tasks {
             into("${intellij.pluginName.get()}/lib/")
         }
     }
+
+    patchPluginXml {
+        untilBuild.set(provider { null })
+
+        changeNotes.set(provider {
+            changelog.renderItem(
+                changelog
+                    .getLatest()
+                    .withHeader(false)
+                    .withEmptySections(false),
+                org.jetbrains.changelog.Changelog.OutputType.HTML
+            )
+        })
+    }
+
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,6 @@
 <idea-plugin>
   <id>com.intellij.plugin.adernov.powershell</id>
   <name>PowerShell</name>
-  <version>2.0.9</version>
   <vendor email="andrey.dernov@gmail.com" url="https://github.com/ant-druha/PowerShell/issues">andrey.dernov@gmail.com</vendor>
 
   <description><![CDATA[
@@ -10,121 +9,6 @@
     <b>Plugin page:</b> <a href="https://plugins.jetbrains.com/plugin/10249">https://plugins.jetbrains.com/plugin/10249</a>
     ]]></description>
 
-  <change-notes><![CDATA[
-  <html lang="en">
-        <dl>
-          <dt>Unreleased<br></dt>
-          <dd>&#183; Minimal supported IntelliJ version is now 2023.2;</dd>
-          <dd>&#183; <a href="https://github.com/ant-druha/intellij-powershell/pull/45">#45</a>: Upgrade PSScriptAnalyzer from 1.17.1 to 1.19.0;</dd>
-          <dd>&#183; <a href="https://github.com/ant-druha/intellij-powershell/pull/75">#75</a>: Add indents for array elements when formatting;</dd>
-          <dd>&#183; <a href="https://github.com/ant-druha/intellij-powershell/pull/90">#90</a>: Allow for more user interaction with the run configuration in terminal (use PTY when available);</dd>
-          <dd>&#183; <a href="https://github.com/ant-druha/intellij-powershell/pull/89">#89</a>: Allow entering the executables from <code>PATH</code> in the plugin settings.</dd>
-
-          <dt>2.0.10 update<br></dt>
-          <dd>&#183; Fixing <a href="https://github.com/ant-druha/intellij-powershell/issues/76">76 Exception thrown when plugin is enabled but no powershell is found in the path</a> ;</dd>
-
-          <dt>2.0.9 update<br></dt>
-          <dd>&#183; 2021.3 compatibility fixes;</dd>
-          
-          <dt>2.0.8 update<br></dt>
-          <dd>&#183; 2021.3 compatibility fixes;</dd>
-          <dd>&#183; Run Configuration: Path Macros for Working Directory paths.</dd>
-
-          <dt>2.0.7 update<br></dt>
-          <dd>&#183; Ability to set PowerShell version globally and for Run Configuration;</dd>
-          <dd>&#183; Run Configuration: ability to specify environment variables;</dd>
-          <dd>&#183; macOS ARM support;</dd>
-
-          <dt>2.0.6 update<br></dt>
-          <dd>&#183; <a href="https://github.com/ant-druha/intellij-powershell/issues/40">40</a> - Run configuration keeps getting renamed when opening or editing.</dd>
-          <dd>&#183; 2021.1 version compatibility</dd>
-          
-          <dt>2.0.5 update<br></dt>
-          <dd>&#183; <a href="https://github.com/ant-druha/intellij-powershell/pull/48">48</a> - Adds simplest code folding: for code blocks, arrays.</dd>
-
-          <dt>2.0.4 Bug fix update<br></dt>
-          <dd>&#183; <a href="https://github.com/ant-druha/intellij-powershell/issues/38">38</a> - UnsupportedClassVersionError running 2019.3 under 1.8 JDK.</dd>
-          
-          <dt>2.0.3 Bug fix update<br></dt>
-          <dd>&#183; <a href="https://github.com/ant-druha/intellij-powershell/issues/33">33</a> - Get rid of implicit dependency on Java plugin;</dd>
-          <dd>&#183; Bug fixes and Platform API maintenance update.</dd>
-
-          <dd>&#183; IntelliJ 2019.2 compatibility;</dd>
-          <dd>&#183; <a href="https://github.com/ant-druha/intellij-powershell/issues/24">24</a> - Parenthesized expression parsing error;</dd>
-
-          <dt>2.0.1 Bug fix update<br></dt>
-          <dd>&#183; <a href="https://github.com/ant-druha/PowerShell/issues/10">10</a> - Script Arguments not working as expected;</dd>
-          <dd>&#183; <a href="https://github.com/ant-druha/PowerShell/issues/12">12</a> - Memory (project) leak in plugin.</dd>
-          
-          <dt>2.0.0 Adds support for PowerShell ScriptAnalyzer code checker in IDE Editor<br></dt>
-          <dd>&#183; <a href="https://github.com/ant-druha/PowerShell/issues/9">9</a> - PowerShell ScriptAnalyzer support in IDE Editor;</dd>
-          <dd>&#183; <a href="https://github.com/ant-druha/PowerShell/issues/6">6</a> - Update PowerShell Language server version;</dd>
-          <dd>&#183; <a href="https://github.com/ant-druha/PowerShell/issues/5">5</a> - Reformat code Error;</dd>
-          <dd>&#183; <a href="https://github.com/ant-druha/PowerShell/issues/3">3</a> - Run/Debug configuration: ability to set working directory;</dd>
-          <dd>&#183; <a href="https://github.com/ant-druha/PowerShell/issues/2">2</a> - NullPointerException during normal IDE operation;</dd>
-          <dd>&#183; <a href="https://github.com/ant-druha/PowerShell/issues/1">1</a> - Exception on PyCharm launch.</dd>
-          
-          <dt>1.1.1 Adds integrated PowerShell console<br></dt>
-          <dd>&#183; <a href="https://bitbucket.org/adernov/powershell/issues/22">22</a> - Integrated PowerShell Console;</dd>
-          <dd>&#183; <a href="https://bitbucket.org/adernov/powershell/issues/18">18</a> - Remote files editing with 'psedit' command in PowerShell console.</dd>
-
-          <dt>1.1.0<br></dt>
-          <dd>&#183; Language injections in interpolated strings;</dd>
-          <dd>&#183; <a href="https://bitbucket.org/adernov/powershell/issues/19">19</a> - Source formatting does not omit "@ at the beginning of line;</dd>
-          <dd>&#183; <a href="https://bitbucket.org/adernov/powershell/issues/20">20</a> - Handle drive letters in unc path;</dd>
-          <dd>&#183; <a href="https://bitbucket.org/adernov/powershell/issues/21">21</a> - NCDFE if IntelliLang plugin is not installed.</dd>
-
-          
-          <dt>1.0.2 Update<br></dt>
-          <dd>&#183; <a href="https://bitbucket.org/adernov/powershell/issues/11">11</a> - "using" keyword not picked up in;</dd>
-          <dd>&#183; More pre-defined <a href="https://www.jetbrains.com/help/idea/live-templates.html">Live Templates</a> snippets;</dd>
-          <dd>&#183; Use '-File' parameter to specify the script file to run.</dd>
-
-          <dt>1.0.1 Bug fix update<br></dt>
-          <dd>&#183; <a href="https://bitbucket.org/adernov/powershell/issues/8">8</a> - Exception shown on LSP communication failure</dd>
-          <dd>&#183; <a href="https://bitbucket.org/adernov/powershell/issues/9">9</a> - Language server fails to start if path to startup script contains spaces.</dd>
-
-            <dt>1.0.0 Language Server Protocol support<br></dt>
-            <dd>&#183; Plugin now bundles <a href="https://github.com/PowerShell/PowerShellEditorServices">PowerShellEditorServices module</a> (same as VSCode) to provide Editor assistance;</dd>
-            <dd>&#183;Supported requests:<br>
-                - <i>textDocument/didOpen</i> (File opened in editor)<br>
-                - <i>textDocument/didClose</i> (File closed in editor)<br>
-                - <i>textDocument/didChange</i> (Editor document text changes)<br>
-                - <i>textDocument/completion</i> (Editor Auto completion).
-            </dd>
-
-            <dt>0.0.3 Bug fix update<br></dt>
-            <dd>&#183; <a href="https://bitbucket.org/adernov/powershell/issues/3">3</a> - Support PowerShell Scopes like Global or Local for functions</dd>
-            <dd>&#183; <a href="https://bitbucket.org/adernov/powershell/issues/5">5</a> - Support more PowerShell file extensions.</dd>
-            <dd>&#183; <a href="https://bitbucket.org/adernov/powershell/issues/7">7</a> - StackOverflowError on resolving variable that has not definition</dd>
-
-            <dt>0.0.2 Enhanced completion<br></dt>
-            <dd>&#183; Resolve and completion of declared in script type members (methods, properties, constructors);</dd>
-            <dd>&#183; Completion for different contexts (references, types, properties).</dd>
-
-            <dt>0.0.1 Initial editor intellisense support:<br></dt>
-            <dd>&#183; Syntax highlighting;</dd>
-            <dd>&#183; Variables and declared types reference resolve and find usages;</dd>
-            <dd>&#183; Reference and keyword completion;</dd>
-            <dd>&#183; Rename refactoring;</dd>
-            <dd>&#183; Structure view;</dd>
-            <dd>&#183; Colors and Fonts;</dd>
-            <dd>&#183; Code style;</dd>
-            <dd>&#183; Live templates;</dd>
-            <dd>&#183; Run Configuration.</dd>
-        </dl>
-  </html>
-    ]]>
-  </change-notes>
-
-  <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-  <idea-version since-build="213.5744"/>
-
-  <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
-       on how to target different products -->
-  <!-- uncomment to enable plugin in all products
-  <depends>com.intellij.modules.lang</depends>
-  -->
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>
   <depends optional="true" config-file="injection.xml">org.intellij.intelliLang</depends>
@@ -132,7 +16,7 @@
 
   <extensions defaultExtensionNs="com.intellij">
 
-    <fileType name="PowerShell" language="PowerShell" extensions="ps1;psm1;psd1" 
+    <fileType name="PowerShell" language="PowerShell" extensions="ps1;psm1;psd1"
               implementationClass="com.intellij.plugin.powershell.PowerShellFileType" />
 
     <lang.parserDefinition language="PowerShell"


### PR DESCRIPTION
- Converts the changelog from the old HTML format to well-known Keep a Changelog
- Adds some missing details and credits about the old releases when I found appropriate (feel free to update them if you will, this is encouraged under the Keep a Changelog, even for the older releases)
- Certain `plugin.xml` entries, including the changelog, are now auto-generated on build
- As we'll also use the generated changelog for the future releases, I've added a new CI step to validate it (in the future, it'll be also set up to produce and auto-upload the releases)