### PR TITLE
CI: enable Gradle cache cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-cleanup: true
 
       - name: Build
         run: ./gradlew build


### PR DESCRIPTION
This will help us to save space in GitHub Actions cache, especially to keep it clean from older IntelliJ versions.