### PR TITLE
Use per-plugin exception analyzer in new IDEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#89](https://github.com/ant-druha/intellij-powershell/pull/89): Allow entering the executables from `PATH` in the plugin settings, thanks to @ZhengKeli
 
 ### Fixed
-- [$124](https://github.com/ant-druha/intellij-powershell/pull/124): Support placing function name on next line in function definition, thanks to @VladRassokhin
+- [#124](https://github.com/ant-druha/intellij-powershell/pull/124): Support placing function name on next line in function definition, thanks to @VladRassokhin
+
+### Added
+- [#128](https://github.com/ant-druha/intellij-powershell/pull/128): The optional error reports are now sent to the Marketplace in newer IDE versions after the user approval
 
 ## [2.0.10] - 2022-02-25
 ### Fixed

--- a/src/main/kotlin/com/intellij/plugin/powershell/ide/ErrorReportSubmitter.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/ide/ErrorReportSubmitter.kt
@@ -1,17 +1,20 @@
 package com.intellij.plugin.powershell.ide
 
-import com.intellij.diagnostic.ITNReporter
 import com.intellij.openapi.diagnostic.ErrorReportSubmitter
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent
+import com.intellij.openapi.extensions.ExtensionNotApplicableException
 
 class ErrorReportSubmitter : ErrorReportSubmitter() {
-    private val delegate: ErrorReportSubmitter = try {
-        // Added in 233.2912
-        Class.forName("com.intellij.diagnostic.JetBrainsMarketplaceErrorReportSubmitter")
-                .declaredConstructors.first().newInstance() as ErrorReportSubmitter
-    } catch (e: Throwable) {
-        ITNReporter()
+
+  private val delegate: ErrorReportSubmitter
+  init {
+    try {
+      delegate = Class.forName("com.intellij.diagnostic.JetBrainsMarketplaceErrorReportSubmitter")
+        .declaredConstructors.first().newInstance() as ErrorReportSubmitter
+    } catch (e: ClassNotFoundException) {
+      throw ExtensionNotApplicableException.create()
     }
+  }
 
     override fun changeReporterAccount(parentComponent: java.awt.Component): Unit = delegate.changeReporterAccount(parentComponent)
 

--- a/src/main/kotlin/com/intellij/plugin/powershell/ide/ErrorReportSubmitter.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/ide/ErrorReportSubmitter.kt
@@ -1,0 +1,26 @@
+package com.intellij.plugin.powershell.ide
+
+import com.intellij.diagnostic.ITNReporter
+import com.intellij.openapi.diagnostic.ErrorReportSubmitter
+import com.intellij.openapi.diagnostic.IdeaLoggingEvent
+
+class ErrorReportSubmitter : ErrorReportSubmitter() {
+    private val delegate: ErrorReportSubmitter = try {
+        // Added in 233.2912
+        Class.forName("com.intellij.diagnostic.JetBrainsMarketplaceErrorReportSubmitter")
+                .declaredConstructors.first().newInstance() as ErrorReportSubmitter
+    } catch (e: Throwable) {
+        ITNReporter()
+    }
+
+    override fun changeReporterAccount(parentComponent: java.awt.Component): Unit = delegate.changeReporterAccount(parentComponent)
+
+    override fun getPrivacyNoticeText(): String? = delegate.privacyNoticeText
+
+    override fun getReportActionText(): String = delegate.reportActionText
+
+    override fun getReporterAccount(): String? = delegate.reporterAccount
+
+    override fun submit(events: Array<IdeaLoggingEvent>, additionalInfo: String?, parentComponent: java.awt.Component, consumer: com.intellij.util.Consumer<in com.intellij.openapi.diagnostic.SubmittedReportInfo>): Boolean =
+            delegate.submit(events, additionalInfo, parentComponent, consumer)
+}

--- a/src/main/kotlin/com/intellij/plugin/powershell/ide/ErrorReportSubmitter.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/ide/ErrorReportSubmitter.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.extensions.ExtensionNotApplicableException
 class ErrorReportSubmitter : ErrorReportSubmitter() {
 
   private val delegate: ErrorReportSubmitter
+
   init {
     try {
       delegate = Class.forName("com.intellij.diagnostic.JetBrainsMarketplaceErrorReportSubmitter")
@@ -16,14 +17,20 @@ class ErrorReportSubmitter : ErrorReportSubmitter() {
     }
   }
 
-    override fun changeReporterAccount(parentComponent: java.awt.Component): Unit = delegate.changeReporterAccount(parentComponent)
+  override fun changeReporterAccount(parentComponent: java.awt.Component): Unit =
+    delegate.changeReporterAccount(parentComponent)
 
-    override fun getPrivacyNoticeText(): String? = delegate.privacyNoticeText
+  override fun getPrivacyNoticeText(): String? = delegate.privacyNoticeText
 
-    override fun getReportActionText(): String = delegate.reportActionText
+  override fun getReportActionText(): String = delegate.reportActionText
 
-    override fun getReporterAccount(): String? = delegate.reporterAccount
+  override fun getReporterAccount(): String? = delegate.reporterAccount
 
-    override fun submit(events: Array<IdeaLoggingEvent>, additionalInfo: String?, parentComponent: java.awt.Component, consumer: com.intellij.util.Consumer<in com.intellij.openapi.diagnostic.SubmittedReportInfo>): Boolean =
-            delegate.submit(events, additionalInfo, parentComponent, consumer)
+  override fun submit(
+    events: Array<IdeaLoggingEvent>,
+    additionalInfo: String?,
+    parentComponent: java.awt.Component,
+    consumer: com.intellij.util.Consumer<in com.intellij.openapi.diagnostic.SubmittedReportInfo>
+  ): Boolean =
+    delegate.submit(events, additionalInfo, parentComponent, consumer)
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -100,6 +100,8 @@
     <applicationService serviceImplementation="com.intellij.plugin.powershell.lang.lsp.LSPInitMain"/>
 
     <editorFactoryListener implementation="com.intellij.plugin.powershell.lang.lsp.ide.listeners.EditorLSPListener"/>
+
+    <errorHandler implementation="com.intellij.plugin.powershell.ide.ErrorReportSubmitter"/>
   </extensions>
 
   <actions>


### PR DESCRIPTION
I'm not sure whether it will work correctly on old IDEs