### PR TITLE
Build: get rid of Kotlin stdlib dependency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-kotlin.stdlib.default.dependency = true
+kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
I can't remember how I ended up with putting `true` there, but apparently I meant to put `false` :)

This makes the distribution a bit smaller.