### PR TITLE
Fix compilation when Java newer than 17 is used to run Gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,8 @@ tasks {
 
   withType<JavaCompile> {
     options.encoding = "UTF-8"
+    sourceCompatibility = "17"
+    targetCompatibility = "17"
   }
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions.jvmTarget = "17"


### PR DESCRIPTION
If `kotlinOptions.jvmTarget` is set, both `sourceCompatibility` and `targetCompatibility` should be also set.