### PR TITLE
CI: set timeout for jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   main:
     runs-on: ${{ matrix.image }}
+    timeout-minutes: 15
     strategy:
       matrix:
         image: [macos-12, ubuntu-22.04, windows-2022]


### PR DESCRIPTION
In my fork I've once got 6 hours Windows job, seems waste of resources.