### PR TITLE
CI: stop removing the stale label when issues are updated

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,5 +16,6 @@ jobs:
         with:
           days-before-stale: -1
           stale-issue-label: 'status:waiting-for-info'
+          remove-stale-when-updated: 'false'
           days-before-close: 14
           close-issue-message: 'This issue was closed because it has been open for 14 days, but no requested information was received. Please leave a comment if you think this is a mistake.'


### PR DESCRIPTION
I prefer manage this label myself.