### PR TITLE
License: move the licensing information to the README file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,8 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Andrey Dernov
-   Copyright 2023 intellij-powershell contributors
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/MAINTAINERSHIP.md
+++ b/MAINTAINERSHIP.md
@@ -6,7 +6,7 @@ Release
 
 To release a new version, follow these steps.
 
-1. Update the copyright year in the `LICENSE` file, if required.
+1. Update the copyright year in the `README.md` file, if required.
 2. Choose the new version. It should consist of three numbers (i.e. `1.0.0`).
 3. Change the version number in the `build.gradle.kts` (`version = "…"`).
 4. Make sure there's a properly formed version entry in the `CHANGELOG.md`.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,25 @@ Documentation
 -------------
 - [Changelog][docs.changelog]
 - [Contributor Guide][docs.contributing]
-- [License (Apache 2)][docs.license]
 - [Maintainership][docs.maintainership]
+
+[License][docs.license]
+---------
+Copyright 2018 Andrey Dernov
+
+Copyright 2023 intellij-powershell contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 [badge-plugins]: https://img.shields.io/jetbrains/plugin/v/10249?label=powershell
 [docs.changelog]: ./CHANGELOG.md


### PR DESCRIPTION
Now please don't get scared! I am not changing (and do not have intention to) anything important.

The info in the LICENSE was stored in the appendix that contains a template, explaining how readers may apply the license to their own projects. The placeholders there aren't meant to be replaced in the original file.

I've had a minor consultation with a lawyer (on a matter related to another Apache2-licensed OSS project, not this one) and updated the licensing information accordingly.

Neither the license nor the list of the copyright holders changes, just the place where we update the copyright year does.