### PR TITLE
CI: process server upload errors better

### DIFF
--- a/src/scripts/Publish-Distribution.ps1
+++ b/src/scripts/Publish-Distribution.ps1
@@ -25,11 +25,12 @@ $ErrorActionPreference = 'Stop'
 
 $file = & "$PSScriptRoot/Get-Distribution.ps1" -DistributionsPath $DistributionsPath
 curl -i `
+    --fail-with-body `
     --header "Authorization: Bearer $AuthToken" `
     -F xmlId=$PluginXmlId `
     -F file=@$file `
     https://plugins.jetbrains.com/plugin/uploadPlugin
 
 if (!$?) {
-    throw "Curl failed with exit code $LASTEXITCODE"
+   throw "Curl failed with exit code $LASTEXITCODE"
 }

--- a/src/scripts/Publish-Distribution.ps1
+++ b/src/scripts/Publish-Distribution.ps1
@@ -1,23 +1,23 @@
 <#
-    .SYNOPSIS
-        This script publishes the plugin distribution from the $DistributionsLocation to the JetBrains Marketplace.
-    .PARAMETER SourceRootPath
-        Path to the project source root.
-    .PARAMETER DistributionsPath
-        Path to the directory containing compressed plugin distribution.
-    .PARAMETER PluginXmlId
-        Plugin identifier.
-    .PARAMETER Channel
-        Channel name to publish the plugin.
-    .PARAMETER AuthToken
-        Token to authenticate to the Marketplace.
+  .SYNOPSIS
+    This script publishes the plugin distribution from the $DistributionsLocation to the JetBrains Marketplace.
+  .PARAMETER SourceRootPath
+    Path to the project source root.
+  .PARAMETER DistributionsPath
+    Path to the directory containing compressed plugin distribution.
+  .PARAMETER PluginXmlId
+    Plugin identifier.
+  .PARAMETER Channel
+    Channel name to publish the plugin.
+  .PARAMETER AuthToken
+    Token to authenticate to the Marketplace.
 #>
 param (
-    [string] $SourceRootPath = "$PSScriptRoot/../..",
-    [string] $DistributionsPath = "$SourceRootPath/build/distributions",
-    [string] $PluginXmlId = 'com.intellij.plugin.adernov.powershell',
-    [Parameter(Mandatory = $true)]
-    [string] $AuthToken
+  [string] $SourceRootPath = "$PSScriptRoot/../..",
+  [string] $DistributionsPath = "$SourceRootPath/build/distributions",
+  [string] $PluginXmlId = 'com.intellij.plugin.adernov.powershell',
+  [Parameter(Mandatory = $true)]
+  [string] $AuthToken
 )
 
 Set-StrictMode -Version Latest
@@ -25,12 +25,12 @@ $ErrorActionPreference = 'Stop'
 
 $file = & "$PSScriptRoot/Get-Distribution.ps1" -DistributionsPath $DistributionsPath
 curl -i `
-    --fail-with-body `
-    --header "Authorization: Bearer $AuthToken" `
-    -F xmlId=$PluginXmlId `
-    -F file=@$file `
-    https://plugins.jetbrains.com/plugin/uploadPlugin
+  --fail-with-body `
+  --header "Authorization: Bearer $AuthToken" `
+  -F xmlId=$PluginXmlId `
+  -F file=@$file `
+  https://plugins.jetbrains.com/plugin/uploadPlugin
 
 if (!$?) {
-   throw "Curl failed with exit code $LASTEXITCODE"
+ throw "Curl failed with exit code $LASTEXITCODE"
 }


### PR DESCRIPTION
This should fix the error we've had in 2.4.0 when the Marketplace server was returning 403, but the script wasn't reporting any errors.