### PR TITLE
Migrate to Gradle version catalog, enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Dependabot configuration:
+# https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for Gradle dependencies
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,5 +2,6 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="StructuralWrap" enabled="false" level="TYPO" enabled_by_default="false" />
+    <inspection_tool class="UnusedVersionCatalogEntry" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,15 +2,15 @@ import org.jetbrains.intellij.tasks.PrepareSandboxTask
 
 plugins {
   id("java")
-  id("org.jetbrains.changelog") version "2.2.0"
-  id("org.jetbrains.grammarkit") version "2022.3.2.2"
-  id("org.jetbrains.intellij") version "1.15.0"
-  id("org.jetbrains.kotlin.jvm") version "1.9.0"
+  alias(libs.plugins.changelog)
+  alias(libs.plugins.grammarkit)
+  alias(libs.plugins.intellij)
+  alias(libs.plugins.kotlin)
 }
 
 intellij {
   type.set("IC")
-  version.set("2023.2")
+  version.set(libs.versions.intellij)
   plugins.set(listOf("org.intellij.intelliLang", "terminal"))
   pluginName.set("PowerShell")
 }
@@ -36,12 +36,11 @@ repositories {
 }
 
 dependencies {
-  implementation("com.kohlschutter.junixsocket:junixsocket-common:2.3.3")
-  implementation("com.kohlschutter.junixsocket:junixsocket-native-common:2.3.3")
+  implementation(libs.bundles.junixsocket)
 
-  implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.3.0")
+  implementation(libs.lsp4j)
   testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
-  testImplementation("junit:junit:4.11")
+  testImplementation(libs.junit)
 }
 
 configurations {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,18 @@
+[versions]
+intellij = "2023.2"
+junixsocket = "2.3.3"
+
+[libraries]
+junixsocket-common = { module = "com.kohlschutter.junixsocket:junixsocket-common", version.ref = "junixsocket" }
+junixsocket-native-common = { module = "com.kohlschutter.junixsocket:junixsocket-native-common", version.ref = "junixsocket" }
+lsp4j = "org.eclipse.lsp4j:org.eclipse.lsp4j:0.3.0"
+junit = "junit:junit:4.11"
+
+[bundles]
+junixsocket = ["junixsocket-common", "junixsocket-native-common"]
+
+[plugins]
+changelog = { id = "org.jetbrains.changelog", version = "2.2.0" }
+grammarkit = { id = "org.jetbrains.grammarkit", version = "2022.3.2.2" }
+intellij = { id = "org.jetbrains.intellij", version = "1.15.0" }
+kotlin = { id = "org.jetbrains.kotlin.jvm", version = "1.9.0" }


### PR DESCRIPTION
This PR migrates the used dependency versions to the Gradle version catalog. This allows various automations to easily parse the project dependency list.

Also, it enables Dependabot to automatically check the updates for our dependencies.