### PR TITLE
Utils: pass the `-NonInteractive` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#257](https://github.com/ant-druha/intellij-powershell/pull/257): pass `-NoProfile` to PowerShell when detecting its version, to determine the version faster and avoid possible problems caused by shell customizations
 
   Thanks to @En3Tho for the contribution.
+- [#259](https://github.com/ant-druha/intellij-powershell/pull/259): additionally, pass `-NonInteractive` argument
 
 ## [2.6.0] - 2024-03-24
 ### Changed

--- a/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/PSLanguageHostUtils.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/PSLanguageHostUtils.kt
@@ -8,11 +8,8 @@ import com.intellij.plugin.powershell.ide.run.checkExists
 import com.intellij.plugin.powershell.ide.run.getModuleVersion
 import com.intellij.plugin.powershell.ide.run.join
 import com.intellij.util.io.awaitExit
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.*
 import kotlinx.coroutines.future.asCompletableFuture
-import kotlinx.coroutines.runInterruptible
 import java.io.InputStream
 import java.util.concurrent.CompletableFuture
 
@@ -56,7 +53,7 @@ object PSLanguageHostUtils {
 private suspend fun readPowerShellVersion(exePath: String): PSVersionInfo {
   var process: Process? = null
   val commandString = "(\$PSVersionTable.PSVersion, \$PSVersionTable.PSEdition) -join ' '"
-  val commandLine = GeneralCommandLine(exePath, "–NoProfile", "-Command", commandString)
+  val commandLine = GeneralCommandLine(exePath, "–NoProfile", "-NonInteractive", "-Command", commandString)
   return coroutineScope {
     try {
       process = commandLine.createProcess()


### PR DESCRIPTION
Closes #259.