### PR TITLE
LanguageHostConnectionManager: get rid of redundant parameter

### DIFF
--- a/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/EditorServicesLanguageHostStarter.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/EditorServicesLanguageHostStarter.kt
@@ -193,7 +193,7 @@ open class EditorServicesLanguageHostStarter(protected val myProject: Project) :
     return file
   }
 
-  override fun createProcess(project: Project, command: List<String>, environment: Map<String, String>?): Process {
+  override fun createProcess(command: List<String>, environment: Map<String, String>?): Process {
     return GeneralCommandLine(command)
       .withEnvironment(environment)
       .createProcess()
@@ -275,7 +275,7 @@ open class EditorServicesLanguageHostStarter(protected val myProject: Project) :
     cachedPowerShellExtensionDir = null
     cachedEditorServicesModuleVersion = null
     val commandLine = buildCommandLine()
-    val process = createProcess(myProject, commandLine, mapOf(INTELLIJ_POWERSHELL_PARENT_PID to ProcessHandle.current().pid().toString()))
+    val process = createProcess(commandLine, mapOf(INTELLIJ_POWERSHELL_PARENT_PID to ProcessHandle.current().pid().toString()))
     val pid: Long = getProcessID(process)
     processOutput(
       process,

--- a/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/LanguageHostConnectionManager.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/LanguageHostConnectionManager.kt
@@ -1,6 +1,5 @@
 package com.intellij.plugin.powershell.lang.lsp.languagehost
 
-import com.intellij.openapi.project.Project
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -9,7 +8,7 @@ interface LanguageHostConnectionManager {
   fun closeConnection()
   fun isConnected(): Boolean
   fun getProcess(): Process?
-  fun createProcess(project: Project, command: List<String>, environment: Map<String, String>?): Process
+  fun createProcess(command: List<String>, environment: Map<String, String>?): Process
   fun connectServer(server: LanguageServerEndpoint) {}
   fun useConsoleRepl(): Boolean = false
 }

--- a/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/terminal/PowerShellConsoleTerminalRunner.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/terminal/PowerShellConsoleTerminalRunner.kt
@@ -100,7 +100,7 @@ class PowerShellConsoleTerminalRunner(project: Project) : EditorServicesLanguage
 
   override fun getLogFileName(): String = "EditorServices-IJ-Console-${getSessionCount()}"
 
-  override fun createProcess(project: Project, command: List<String>, environment: Map<String, String>?): PtyProcess {
+  override fun createProcess(command: List<String>, environment: Map<String, String>?): PtyProcess {
     LOG.info("Language server starting... exe: '$command'")
     val process = createPtyProcess(myProject, command.toTypedArray(), environment)
     try {


### PR DESCRIPTION
Can't remember what stopped me from posting this earlier.