### PR TITLE
Target the lowest IntelliJ version in the latest wave

### DIFF
--- a/intellij-updater.json
+++ b/intellij-updater.json
@@ -3,7 +3,9 @@
     "file": "gradle/libs.versions.toml",
     "field": "intellij",
     "kind": "intellij-idea-community",
-    "versionFlavor": "release"
+    "versionFlavor": "release",
+    "versionConstraint": "latestWave",
+    "order": "oldest"
   }, {
     "file": "gradle/libs.versions.toml",
     "field": "intellijPreview",


### PR DESCRIPTION
I.e. 242.0, to widen the supported IDE version range.

We test against the latest anyway, so it should be fine.