### PR TITLE
CI: accommodate the v-prefix for the PowerShellScriptAnalyzer versioning

### DIFF
--- a/src/scripts/Update-Dependencies.ps1
+++ b/src/scripts/Update-Dependencies.ps1
@@ -36,7 +36,7 @@ $pses = Invoke-RestMethod 'https://api.github.com/repos/PowerShell/PowerShellEdi
 function ReadLatestVersions
 {
   @{
-    PSScriptAnalyzer = [Version] $psScriptAnalyzer.tag_name
+    PSScriptAnalyzer = [Version] $psScriptAnalyzer.tag_name.Trim('v')
     PowerShellEditorServices = [Version] $pses.tag_name.Trim('v')
   }
 }


### PR DESCRIPTION
Recently, the CI updater script started failing because of this.