### PR TITLE
CI: fix the dependency release notes presentation

### DIFF
--- a/src/scripts/Update-Dependencies.ps1
+++ b/src/scripts/Update-Dependencies.ps1
@@ -146,7 +146,7 @@ if ($hasChanges)
 
 The updated packages' release notes follow below.
 
-'@ + $updateReleaseNoteStrings -join "`n"
+'@ + ($updateReleaseNoteStrings -join "`n`n")
 }
 
 ApplyUpdates $updates


### PR DESCRIPTION
Without this, our PRs updating several dependencies at once had weird markup (ex. #348).