### PR TITLE
(#352) Editor: Refactor PowerShellCodeStyleSettingsProvider

### DIFF
--- a/src/main/kotlin/com/intellij/plugin/powershell/ide/editor/formatting/PowerShellCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/ide/editor/formatting/PowerShellCodeStyleSettingsProvider.kt
@@ -1,5 +1,7 @@
 package com.intellij.plugin.powershell.ide.editor.formatting
 
+import com.intellij.lang.Language
+import com.intellij.plugin.powershell.lang.PowerShellLanguage
 import com.intellij.psi.codeStyle.CodeStyleConfigurable
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.codeStyle.CodeStyleSettingsProvider
@@ -10,9 +12,7 @@ import com.intellij.psi.codeStyle.CustomCodeStyleSettings
  */
 class PowerShellCodeStyleSettingsProvider : CodeStyleSettingsProvider() {
 
-  override fun getConfigurableDisplayName(): String {
-    return "PowerShell"
-  }
+  override fun getLanguage(): Language = PowerShellLanguage.INSTANCE
 
   override fun createConfigurable(settings: CodeStyleSettings, modelSettings: CodeStyleSettings): CodeStyleConfigurable {
     return PowerShellCodeStyleConfigurable(settings, modelSettings)


### PR DESCRIPTION
Replaced getConfigurableDisplayName() with getLanguage() to align with API requirements.

Closes #352 