### PR TITLE
Revert "Dependencies: update IntelliJ-based IDE versions"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-intellij = "2025.1"
+intellij = "251.23774.318-EAP-SNAPSHOT"
 intellijPreview = "251.23774.318-EAP-SNAPSHOT"
 junixsocket = "2.10.1"
 lsp4j = "0.24.0"


### PR DESCRIPTION
This reverts commit 893a0502219f0e7ced0c9cf23b9ab7c8584d97f7.

Temporarily until we migrate to the fixed version of Gradle plugin.