### PR TITLE
Build: migrate to the modern verification workflow

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -102,7 +103,13 @@ intellijPlatform {
   }
   pluginVerification {
     ides {
-      recommended()
+      select {
+        channels = listOf(
+          ProductRelease.Channel.RELEASE,
+          ProductRelease.Channel.EAP
+        )
+        untilBuild = providers.gradleProperty("untilBuildForVerification")
+      }
     }
     freeArgs.addAll(
       "-mute", "ForbiddenPluginIdPrefix",
@@ -259,8 +266,6 @@ tasks {
   }
 
   patchPluginXml {
-    untilBuild.set(provider { null })
-
     changeNotes.set(provider {
       changelog.renderItem(
         changelog
@@ -270,13 +275,5 @@ tasks {
         org.jetbrains.changelog.Changelog.OutputType.HTML
       )
     })
-  }
-
-  if (libs.versions.intellij.get() != libs.versions.intellijPreview.get()) {
-    val testPreview by intellijPlatformTesting.testIde.registering {
-      version = libs.versions.intellijPreview
-    }
-
-    check { dependsOn(testPreview.name) }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,9 @@ kotlin.stdlib.default.dependency=false
 
 pluginVersion=2.11.0
 
+# This is the last version used for plugin verification:
+untilBuildForVerification=262.*
+
 # 30 MiB:
 maxUnpackedPluginBytes=31457280
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 intellij = "2025.3"
-intellijPreview = "2025.3"
 junit-platform = "6.0.2"
 junit5 = "5.13.4"
 junixsocket = "2.10.1"

--- a/intellij-updater.json
+++ b/intellij-updater.json
@@ -1,21 +1,26 @@
 {
-  "updates": [{
-    "file": "gradle/libs.versions.toml",
-    "field": "intellij",
-    "kind": "intellij-idea-community",
-    "versionFlavor": "release",
-    "versionConstraint": "latestWave",
-    "order": "oldest"
-  }, {
-    "file": "gradle/libs.versions.toml",
-    "field": "intellijPreview",
-    "kind": "intellij-idea-community",
-    "versionFlavor": "eap"
-  }, {
-    "file": "gradle/libs.versions.toml",
-    "field": "kotlin",
-    "kind": "kotlin",
-    "versionFlavor": "release"
-  }],
+  "updates": [
+    {
+      "file": "gradle/libs.versions.toml",
+      "field": "intellij",
+      "kind": "intellij-idea-community",
+      "versionFlavor": "release",
+      "versionConstraint": "latestWave",
+      "order": "oldest"
+    },
+    {
+      "file": "gradle.properties",
+      "field": "untilBuildForVerification",
+      "kind": "intellij-idea",
+      "versionFlavor": "release",
+      "augmentation": "nextMajor"
+    },
+    {
+      "file": "gradle/libs.versions.toml",
+      "field": "kotlin",
+      "kind": "kotlin",
+      "versionFlavor": "release"
+    }
+  ],
   "prBodyPrefix": "## Maintainer Note\n> [!WARNING]\n> This PR will not trigger CI by default. Please **close it and reopen manually** to trigger the CI.\n>\n> Unfortunately, this is a consequence of the current GitHub Action security model (by default, PRs created automatically aren't allowed to trigger other automation)."
 }


### PR DESCRIPTION
This is what I use in other plugins I maintain: we build and test against the latest stable version, plus ve run the plugin verifier against the latest EAP.

We'll branch out to build against EAP at the moment it breaks our plugin, according to the plugin verifier.