### PR TITLE
EditorServices: migrate to JDK's Unix sockets instead of a library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+### Changed
+- Migrate Unix socket transport from `com.kohlschutter.junixsocket` to JDK Unix-domain socket APIs.
+
 ## [2.11.0] - 2025-07-05
 ### Changed
 - **Requirement update:** IntelliJ Platform 252.23591.19 (2025.2 EAP) is now the minimal supported version.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,7 +73,6 @@ dependencies {
     pluginVerifier()
   }
 
-  implementation(libs.bundles.junixsocket)
   implementation(libs.lsp4j)
   implementation(libs.lsp4jdebug)
   testImplementation("org.jetbrains.kotlin:kotlin-test-junit")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 intellij = "2026.1"
 junit-platform = "6.0.2"
 junit5 = "6.1.1"
-junixsocket = "2.10.1"
 kotlin = "2.3.20"
 lsp4j = "1.0.0"
 
@@ -12,14 +11,9 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", vers
 junit-platform-engine = { module = "org.junit.platform:junit-platform-engine", version.ref = "junit-platform" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit5" }
-junixsocket-common = { module = "com.kohlschutter.junixsocket:junixsocket-common", version.ref = "junixsocket" }
-junixsocket-native-common = { module = "com.kohlschutter.junixsocket:junixsocket-native-common", version.ref = "junixsocket" }
 lsp4j = {module = "org.eclipse.lsp4j:org.eclipse.lsp4j", version.ref = "lsp4j"}
 lsp4jdebug = {module = "org.eclipse.lsp4j:org.eclipse.lsp4j.debug", version.ref = "lsp4j"}
 openTest4J = "org.opentest4j:opentest4j:1.3.0"
-
-[bundles]
-junixsocket = ["junixsocket-common", "junixsocket-native-common"]
 
 [plugins]
 changelog = "org.jetbrains.changelog:2.5.0"

--- a/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/EditorServicesLanguageHostStarter.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/EditorServicesLanguageHostStarter.kt
@@ -41,6 +41,7 @@ import java.net.Socket
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
 import java.nio.channels.SocketChannel
+import java.nio.channels.UnsupportedAddressTypeException
 import java.nio.charset.Charset
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -131,15 +132,15 @@ open class EditorServicesLanguageHostStarter(protected val myProject: Project) :
             val outSf = BufferedOutputStream(Channels.newOutputStream(serverReadChannel))
             Pair(inSf, outSf)
           } else {
-            val readChannel = openUnixDomainSocket(readPipeName)
+            val serverReadChannel = openUnixDomainSocket(readPipeName)
             try {
-              val writeChannel = openUnixDomainSocket(writePipeName)
+              val serverWriteChannel = openUnixDomainSocket(writePipeName)
               Pair(
-                Channels.newInputStream(writeChannel),
-                BufferedOutputStream(Channels.newOutputStream(readChannel))
+                Channels.newInputStream(serverWriteChannel),
+                BufferedOutputStream(Channels.newOutputStream(serverReadChannel))
               )
             } catch (e: Exception) {
-              readChannel.close()
+              serverReadChannel.close()
               throw e
             }
           }
@@ -172,16 +173,16 @@ open class EditorServicesLanguageHostStarter(protected val myProject: Project) :
     val path = File(socketPath).toPath()
     val address = try {
       UnixDomainSocketAddress.of(path)
-    } catch (e: UnsupportedOperationException) {
-      throw IOException("JDK Unix-domain sockets are not supported by this runtime environment.", e)
+    } catch (e: IllegalArgumentException) {
+      throw IOException("JDK Unix-domain sockets (\"$path\") are not supported by this runtime environment.", e)
     }
 
     return try {
       SocketChannel.open(address)
-    } catch (e: UnsupportedOperationException) {
-      throw IOException("JDK Unix-domain sockets are not supported by this runtime environment.", e)
-    } catch (e: Exception) {
-      throw IOException("Unable to connect to Unix-domain socket at $path.", e)
+    } catch (e: UnsupportedAddressTypeException) {
+      throw IOException("JDK Unix-domain sockets (\"$path\") are not supported by this runtime environment.", e)
+    } catch (e: IOException) {
+      throw IOException("Unable to connect to Unix-domain socket at \"$path\".", e)
     }
   }
 

--- a/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/EditorServicesLanguageHostStarter.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/EditorServicesLanguageHostStarter.kt
@@ -36,11 +36,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withContext
-import org.newsclub.net.unix.AFUNIXSocket
-import org.newsclub.net.unix.AFUNIXSocketAddress
 import java.io.*
 import java.net.Socket
+import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
 import java.nio.charset.Charset
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -131,11 +131,17 @@ open class EditorServicesLanguageHostStarter(protected val myProject: Project) :
             val outSf = BufferedOutputStream(Channels.newOutputStream(serverReadChannel))
             Pair(inSf, outSf)
           } else {
-            val readSock = AFUNIXSocket.newInstance()
-            val writeSock = AFUNIXSocket.newInstance()
-            readSock.connect(AFUNIXSocketAddress.of(File(readPipeName)))
-            writeSock.connect(AFUNIXSocketAddress.of(File(writePipeName)))
-            Pair(writeSock.inputStream, readSock.outputStream)
+            val readChannel = openUnixDomainSocket(readPipeName)
+            try {
+              val writeChannel = openUnixDomainSocket(writePipeName)
+              Pair(
+                Channels.newInputStream(writeChannel),
+                BufferedOutputStream(Channels.newOutputStream(readChannel))
+              )
+            } catch (e: Exception) {
+              readChannel.close()
+              throw e
+            }
           }
         }
       }
@@ -161,6 +167,23 @@ open class EditorServicesLanguageHostStarter(protected val myProject: Project) :
         }
       }
     }
+
+  private fun openUnixDomainSocket(socketPath: String): SocketChannel {
+    val path = File(socketPath).toPath()
+    val address = try {
+      UnixDomainSocketAddress.of(path)
+    } catch (e: UnsupportedOperationException) {
+      throw IOException("JDK Unix-domain sockets are not supported by this runtime environment.", e)
+    }
+
+    return try {
+      SocketChannel.open(address)
+    } catch (e: UnsupportedOperationException) {
+      throw IOException("JDK Unix-domain sockets are not supported by this runtime environment.", e)
+    } catch (e: Exception) {
+      throw IOException("Unable to connect to Unix-domain socket at $path.", e)
+    }
+  }
 
   /**
    * @throws PowerShellExtensionError


### PR DESCRIPTION
Closes #120.

This will unblock the way to make the plugin dynamically-(re)loadable.