### PR TITLE
PowerShell Extensions: fix the lookup path after plugin rename

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,9 @@
-// SPDX-FileCopyrightText: 2017-2022 Andrey Dernov <https://github.com/ant-druha/>
-// SPDX-FileCopyrightText: 2023-2026 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
-//
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * SPDX-FileCopyrightText: 2017-2022 Andrey Dernov <https://github.com/ant-druha/>
+ * SPDX-FileCopyrightText: 2023-2026 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.models.ProductRelease
@@ -186,7 +188,7 @@ tasks {
     }
   }
 
-  fun PrepareSandboxTask.unpackPsScriptAnalyzer(outDir: Provider<String>) {
+  fun PrepareSandboxTask.unpackPsScriptAnalyzer(outDir: String) {
     inputs.files(psScriptAnalyzer)
     inputs.property("hash", psScriptAnalyzerSha256Hash)
 
@@ -195,7 +197,7 @@ tasks {
     }
 
     from(zipTree(psScriptAnalyzer.singleFile)) {
-      into(outDir.map { "$it/PSScriptAnalyzer" })
+      into("$outDir/PSScriptAnalyzer")
 
       // NuGet stuff:
       exclude("_manifest/**", "_rels/**", "package/**", "[Content_Types].xml", "*.nuspec")
@@ -205,7 +207,7 @@ tasks {
     }
   }
 
-  fun PrepareSandboxTask.unpackPowerShellEditorServices(outDir: Provider<String>) {
+  fun PrepareSandboxTask.unpackPowerShellEditorServices(outDir: String) {
     inputs.files(powerShellEditorServices)
     inputs.property("hash", psesSha256Hash)
     doFirst {
@@ -213,14 +215,14 @@ tasks {
     }
 
     from(zipTree(powerShellEditorServices.singleFile)) {
-      into(outDir.map { "$it/" })
+      into(outDir)
       // We only need this module and not anything else from the archive:
       include("PowerShellEditorServices/**")
     }
   }
 
   withType<PrepareSandboxTask> {
-    val outDir = intellijPlatform.pluginConfiguration.name.map { "$it/lib/LanguageHost/modules" }
+    val outDir = "${project.name}/lib/LanguageHost/modules"
     unpackPsScriptAnalyzer(outDir)
     unpackPowerShellEditorServices(outDir)
   }

--- a/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/PSLanguageHostUtils.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/PSLanguageHostUtils.kt
@@ -1,7 +1,9 @@
-// SPDX-FileCopyrightText: 2018-2021 Andrey Dernov <https://github.com/ant-druha/>
-// SPDX-FileCopyrightText: 2023-2026 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
-//
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * SPDX-FileCopyrightText: 2018-2021 Andrey Dernov <https://github.com/ant-druha/>
+ * SPDX-FileCopyrightText: 2023-2026 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 package com.intellij.plugin.powershell.lang.lsp.languagehost
 
@@ -20,7 +22,7 @@ import java.util.concurrent.CompletableFuture
 
 object PSLanguageHostUtils {
   val LOG: Logger = Logger.getInstance(javaClass)
-  val BUNDLED_PSES_PATH = join(PathManager.getPluginsPath(), "PowerShell/lib/LanguageHost")
+  val BUNDLED_PSES_PATH = join(PathManager.getPluginsPath(), "intellij-powershell/lib/LanguageHost")
 
   fun getPSExtensionModulesDir(psExtensionDir: String): String {
     return if (isExtensionDirectoryFormat(psExtensionDir)) join(psExtensionDir, "modules")

--- a/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/PSLanguageHostUtils.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/PSLanguageHostUtils.kt
@@ -8,7 +8,7 @@
 package com.intellij.plugin.powershell.lang.lsp.languagehost
 
 import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.application.PluginPathManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.plugin.powershell.ide.PluginAppRoot
 import com.intellij.plugin.powershell.ide.run.checkExists
@@ -22,7 +22,10 @@ import java.util.concurrent.CompletableFuture
 
 object PSLanguageHostUtils {
   val LOG: Logger = Logger.getInstance(javaClass)
-  val BUNDLED_PSES_PATH = join(PathManager.getPluginsPath(), "intellij-powershell/lib/LanguageHost")
+  val BUNDLED_PSES_PATH by lazy {
+    PluginPathManager.getPluginResource(PSLanguageHostUtils.javaClass, "lib/LanguageHost")?.path
+      ?: error("Cannot find plugin resources folder.")
+  }
 
   fun getPSExtensionModulesDir(psExtensionDir: String): String {
     return if (isExtensionDirectoryFormat(psExtensionDir)) join(psExtensionDir, "modules")

--- a/src/test/kotlin/com/intellij/plugin/powershell/lang/PSLanguageHostUtilsTests.kt
+++ b/src/test/kotlin/com/intellij/plugin/powershell/lang/PSLanguageHostUtilsTests.kt
@@ -1,6 +1,8 @@
-// SPDX-FileCopyrightText: 2023-2025 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
-//
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * SPDX-FileCopyrightText: 2023-2026 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 package com.intellij.plugin.powershell.lang
 
@@ -16,12 +18,31 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.nio.file.Path
+import kotlin.io.path.Path
+import kotlin.io.path.div
+import kotlin.io.path.exists
 import kotlin.io.path.pathString
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
 @TestApplication
 class PSLanguageHostUtilsTests {
+
+  @Test
+  fun testBundledEditorServicesModulesArePresent() {
+    val bundledPath = Path(PSLanguageHostUtils.BUNDLED_PSES_PATH)
+    val editorServicesModuleDir = bundledPath / "modules" / "PowerShellEditorServices"
+    assertTrue(
+      editorServicesModuleDir.exists(),
+      "Expected bundled EditorServices module directory at ${editorServicesModuleDir.pathString}."
+    )
+
+    val startupScriptPath = Path(PSLanguageHostUtils.getEditorServicesStartupScript(bundledPath.pathString))
+    assertTrue(
+      startupScriptPath.exists(),
+      "Expected bundled EditorServices startup script at ${startupScriptPath.pathString}."
+    )
+  }
 
   @Test
   fun testPowerShell5VersionDetector() {


### PR DESCRIPTION
Closes #464 (thankfully, a bug never exposed to the users).