### PR TITLE
fix(formatter): indent line comments

### DIFF
--- a/src/main/kotlin/com/intellij/plugin/powershell/ide/editor/formatting/PowerShellLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/ide/editor/formatting/PowerShellLanguageCodeStyleSettingsProvider.kt
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2017-2018 Andrey Dernov <https://github.com/ant-druha/>
-// SPDX-FileCopyrightText: 2023-2024 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
+// SPDX-FileCopyrightText: 2023-2026 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -379,6 +379,7 @@ class PowerShellLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsPro
   }
 
   override fun customizeDefaults(defaultSettings: CommonCodeStyleSettings, indentOptions: CommonCodeStyleSettings.IndentOptions) {
+    defaultSettings.LINE_COMMENT_AT_FIRST_COLUMN = false
     defaultSettings.KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE = true
     defaultSettings.RIGHT_MARGIN = 115
     defaultSettings.SPACE_WITHIN_BRACES = true
@@ -409,6 +410,5 @@ class PowerShellLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsPro
   }
 
 }
-
 
 

--- a/src/test/kotlin/com/intellij/plugin/powershell/lang/PowerShellCommenterTest.kt
+++ b/src/test/kotlin/com/intellij/plugin/powershell/lang/PowerShellCommenterTest.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
+// SPDX-FileCopyrightText: 2024-2026 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,6 +11,29 @@ import org.junit.jupiter.api.Test
 
 @TestApplication
 class PowerShellCommenterTest : PowerShellCodeInsightTestBase() {
+
+  @Test
+  fun testLineCommentIndent() {
+    codeInsightTestFixture.configureByText(
+      "file.ps1", """
+      {
+          Write-Output before
+          <caret>comment
+          Write-Output after
+      }
+    """.trimIndent()
+    )
+    codeInsightTestFixture.performEditorAction(IdeActions.ACTION_COMMENT_LINE)
+    codeInsightTestFixture.checkResult(
+      """
+      {
+          Write-Output before
+          #comment
+          Write-Output after
+      }
+    """.trimIndent()
+    )
+  }
 
   @Test
   fun testCommentExtension() {


### PR DESCRIPTION
## What does this PR do?

Keeps PowerShell line comments aligned with the code they comment instead of moving the comment marker to the first column.

The PowerShell code-style defaults now disable first-column line comments, and an editor-action regression test covers a standalone indented line inside a block.

## Related issue

Closes #423

## How was this tested?

- Fail-before/pass-after focused `PowerShellCommenterTest.testLineCommentIndent`
- Full `PowerShellCommenterTest` suite: 2/2 passed
- `./gradlew build` compiled and assembled successfully; its aggregate test task is limited by unavailable PowerShell/PSES on the test host
- `git diff --check`
