### PR TITLE
feat(run): show run icon in file gutter

### DIFF
--- a/src/main/kotlin/com/intellij/plugin/powershell/ide/run/PowerShellRunLineMarkerContributor.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/ide/run/PowerShellRunLineMarkerContributor.kt
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package com.intellij.plugin.powershell.ide.run
+
+import com.intellij.execution.lineMarker.RunLineMarkerContributor
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.project.DumbAware
+import com.intellij.plugin.powershell.psi.impl.PowerShellFile
+import com.intellij.psi.PsiElement
+
+class PowerShellRunLineMarkerContributor : RunLineMarkerContributor(), DumbAware {
+  override fun getInfo(element: PsiElement): Info? {
+    val file = element.containingFile as? PowerShellFile ?: return null
+    if (!file.virtualFile?.extension.equals("ps1", ignoreCase = true) || element !== file.findElementAt(0)) return null
+    return withExecutorActions(AllIcons.RunConfigurations.TestState.Run)
+  }
+}

--- a/src/main/kotlin/com/intellij/plugin/powershell/ide/run/PowerShellRunLineMarkerContributor.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/ide/run/PowerShellRunLineMarkerContributor.kt
@@ -12,8 +12,12 @@ import com.intellij.psi.PsiElement
 
 class PowerShellRunLineMarkerContributor : RunLineMarkerContributor(), DumbAware {
   override fun getInfo(element: PsiElement): Info? {
+    if (element.textOffset != 0) return null
+
     val file = element.containingFile as? PowerShellFile ?: return null
-    if (!file.virtualFile?.extension.equals("ps1", ignoreCase = true) || element !== file.findElementAt(0)) return null
+    if (!file.virtualFile?.extension.equals("ps1", ignoreCase = true)) return null
+    if (element !== file.findElementAt(0)) return null
+
     return withExecutorActions(AllIcons.RunConfigurations.TestState.Run)
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -80,6 +80,8 @@ SPDX-License-Identifier: Apache-2.0
     <configurationType implementation="com.intellij.plugin.powershell.ide.run.PowerShellConfigurationType"/>
     <runConfigurationProducer
         implementation="com.intellij.plugin.powershell.ide.run.PowerShellConfigurationProducer" order="first"/>
+    <runLineMarkerContributor language="PowerShell"
+                              implementationClass="com.intellij.plugin.powershell.ide.run.PowerShellRunLineMarkerContributor"/>
 
     <xdebugger.breakpointType implementation="com.intellij.plugin.powershell.ide.debugger.PowerShellBreakpointType"/>
 

--- a/src/test/kotlin/com/intellij/plugin/powershell/ide/run/PowerShellRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/com/intellij/plugin/powershell/ide/run/PowerShellRunLineMarkerContributorTest.kt
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package com.intellij.plugin.powershell.ide.run
+
+import com.intellij.execution.lineMarker.RunLineMarkerContributor
+import com.intellij.plugin.powershell.testFramework.PowerShellCodeInsightTestBase
+import com.intellij.plugin.powershell.testFramework.RunInEdt
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.junit5.TestApplication
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@TestApplication
+@RunInEdt
+class PowerShellRunLineMarkerContributorTest : PowerShellCodeInsightTestBase() {
+  private val contributor = PowerShellRunLineMarkerContributor()
+
+  @Test
+  fun testScriptHasOneActionableMarker() {
+    val markers = markersFor("script.ps1")
+
+    assertEquals(1, markers.size)
+    assertTrue(markers.single().actions.isNotEmpty())
+  }
+
+  @Test
+  fun testScriptExtensionIsCaseInsensitive() {
+    assertEquals(1, markersFor("script.PS1").size)
+    assertEquals(1, markersFor("script.Ps1").size)
+  }
+
+  @Test
+  fun testModuleAndDataFilesHaveNoMarkers() {
+    assertEquals(emptyList<RunLineMarkerContributor.Info>(), markersFor("module.psm1"))
+    assertEquals(emptyList<RunLineMarkerContributor.Info>(), markersFor("data.psd1"))
+  }
+
+  private fun markersFor(fileName: String): List<RunLineMarkerContributor.Info> {
+    val file = codeInsightTestFixture.configureByText(fileName, "Write-Output 'hello'")
+    return generateSequence(file.findElementAt(0)) { PsiTreeUtil.nextLeaf(it) }
+      .mapNotNull(contributor::getInfo)
+      .toList()
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds a run icon to the gutter for PowerShell `.ps1` scripts.

The marker is attached once at the start of each script and uses IntelliJ's standard executor actions, which reuse the existing PowerShell run-configuration producer. Extension matching is case-insensitive, the contributor remains available during indexing, and module/data files remain unchanged.

## Related issue

Closes #432

## How was this tested?

- Focused run-line-marker tests for lowercase, uppercase, and mixed-case `.ps1`, plus `.psm1` and `.psd1` exclusions
- Prior `./gradlew build` compilation and assembly; aggregate tests retain the documented missing-PowerShell host limitation
- `git diff --check`
