### PR TITLE
fix: accept more custom PSES locations

### DIFF
--- a/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/ide/settings/PowerShellJPanelComponent.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/ide/settings/PowerShellJPanelComponent.kt
@@ -78,7 +78,7 @@ class PowerShellJPanelComponent {
       !EditorServicesLanguageHostStarter.isUseBundledPowerShellExtension()
   }
 
-  fun getPowerShellExtensionPath(): String = psExtensionPathTextField.text.trim()
+  fun getPowerShellExtensionPath(): String = PSLanguageHostUtils.normalizePSExtensionPath(psExtensionPathTextField.text.trim())
 
   fun getPowerShellVersionValue(): String? = psExecutableChooserPanel.versionValue
 
@@ -105,7 +105,7 @@ class PowerShellJPanelComponent {
   }
 
   private fun createExtensionPathField(): TextFieldWithBrowseButton {
-    val descriptor = object : FileChooserDescriptor(false, true, false, false, false, false) {
+    val descriptor = object : FileChooserDescriptor(true, true, false, false, false, false) {
       override fun validateSelectedFiles(files: Array<out VirtualFile>) {
         if (files.isEmpty()) return
         val psEditorServicesPath = files[0].canonicalPath
@@ -113,8 +113,9 @@ class PowerShellJPanelComponent {
           setEditorServicesVersionLabelValue(null)
           return
         }
-        if (getPowerShellExtensionPath() == psEditorServicesPath) return
-        val psLanguageServerVersion = FormUIUtil.getEditorServicesVersion(psEditorServicesPath)
+        val normalizedPath = PSLanguageHostUtils.normalizePSExtensionPath(psEditorServicesPath)
+        if (getPowerShellExtensionPath() == normalizedPath) return
+        val psLanguageServerVersion = FormUIUtil.getEditorServicesVersion(normalizedPath)
         setEditorServicesVersionLabelValue(psLanguageServerVersion)
       }
     }

--- a/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/PSLanguageHostUtils.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/PSLanguageHostUtils.kt
@@ -17,10 +17,13 @@ import com.intellij.plugin.powershell.ide.run.join
 import com.intellij.util.io.awaitExit
 import kotlinx.coroutines.*
 import kotlinx.coroutines.future.asCompletableFuture
+import java.io.File
 import java.io.InputStream
 import java.util.concurrent.CompletableFuture
 
 object PSLanguageHostUtils {
+  private const val EDITOR_SERVICES_MANIFEST = "PowerShellEditorServices.psd1"
+
   val LOG: Logger = Logger.getInstance(javaClass)
   val BUNDLED_PSES_PATH by lazy {
     PluginPathManager.getPluginResource(PSLanguageHostUtils.javaClass, "lib/LanguageHost")?.path
@@ -28,16 +31,33 @@ object PSLanguageHostUtils {
   }
 
   fun getPSExtensionModulesDir(psExtensionDir: String): String {
-    return if (isExtensionDirectoryFormat(psExtensionDir)) join(psExtensionDir, "modules")
-    else psExtensionDir
+    val normalizedDir = normalizePSExtensionPath(psExtensionDir)
+    return if (isExtensionDirectoryFormat(normalizedDir)) join(normalizedDir, "modules")
+    else normalizedDir
   }
 
   fun getEditorServicesStartupScript(psExtensionDir: String): String {
+    val normalizedDir = normalizePSExtensionPath(psExtensionDir)
     return when {
-      isExtensionDirectoryFormat(psExtensionDir) -> join(psExtensionDir, "modules/PowerShellEditorServices/Start-EditorServices.ps1")
-      isStandAloneDirectoryFormat(psExtensionDir) -> "$psExtensionDir/PowerShellEditorServices/Start-EditorServices.ps1"
+      isExtensionDirectoryFormat(normalizedDir) -> join(normalizedDir, "modules/PowerShellEditorServices/Start-EditorServices.ps1")
+      isStandAloneDirectoryFormat(normalizedDir) -> "$normalizedDir/PowerShellEditorServices/Start-EditorServices.ps1"
       else -> join(BUNDLED_PSES_PATH, "modules/PowerShellEditorServices/Start-EditorServices.ps1")
     }
+  }
+
+  fun normalizePSExtensionPath(path: String): String {
+    if (path.isBlank()) return path
+    return runCatching {
+      val selectedFile = File(path)
+      val moduleDirectory = when {
+        !selectedFile.exists() -> null
+        selectedFile.isFile -> selectedFile.parentFile
+        else -> selectedFile
+      }
+      if (moduleDirectory != null && File(moduleDirectory, EDITOR_SERVICES_MANIFEST).isFile) {
+        moduleDirectory.parent ?: path
+      } else path
+    }.getOrDefault(path)
   }
 
   private fun isExtensionDirectoryFormat(psExtensionDir: String): Boolean {

--- a/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/PSLanguageHostUtils.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/lang/lsp/languagehost/PSLanguageHostUtils.kt
@@ -40,7 +40,7 @@ object PSLanguageHostUtils {
     val normalizedDir = normalizePSExtensionPath(psExtensionDir)
     return when {
       isExtensionDirectoryFormat(normalizedDir) -> join(normalizedDir, "modules/PowerShellEditorServices/Start-EditorServices.ps1")
-      isStandAloneDirectoryFormat(normalizedDir) -> "$normalizedDir/PowerShellEditorServices/Start-EditorServices.ps1"
+      isStandAloneDirectoryFormat(normalizedDir) -> File(File(normalizedDir, "PowerShellEditorServices"), "Start-EditorServices.ps1").path
       else -> join(BUNDLED_PSES_PATH, "modules/PowerShellEditorServices/Start-EditorServices.ps1")
     }
   }

--- a/src/test/kotlin/com/intellij/plugin/powershell/lang/PSLanguageHostUtilsTests.kt
+++ b/src/test/kotlin/com/intellij/plugin/powershell/lang/PSLanguageHostUtilsTests.kt
@@ -17,16 +17,52 @@ import kotlinx.coroutines.future.await
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.io.path.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createFile
 import kotlin.io.path.div
 import kotlin.io.path.exists
 import kotlin.io.path.pathString
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
 @TestApplication
 class PSLanguageHostUtilsTests {
+
+  @Test
+  fun testNormalizePSExtensionPath(@TempDir tempDir: Path) {
+    val extensionRoot = (tempDir / "extension").createDirectories()
+    val moduleBase = (extensionRoot / "modules").createDirectories()
+    val moduleDirectory = (moduleBase / "PowerShellEditorServices").createDirectories()
+    val manifest = (moduleDirectory / "PowerShellEditorServices.psd1").createFile()
+    val startupScript = (moduleDirectory / "Start-EditorServices.ps1").createFile()
+    val directChild = (moduleDirectory / "Commands.ps1").createFile()
+
+    assertEquals(extensionRoot.pathString, PSLanguageHostUtils.normalizePSExtensionPath(extensionRoot.pathString))
+    assertEquals(moduleBase.pathString, PSLanguageHostUtils.normalizePSExtensionPath(moduleBase.pathString))
+    assertEquals(moduleBase.pathString, PSLanguageHostUtils.normalizePSExtensionPath(moduleDirectory.pathString))
+    assertEquals(moduleBase.pathString, PSLanguageHostUtils.normalizePSExtensionPath(manifest.pathString))
+    assertEquals(moduleBase.pathString, PSLanguageHostUtils.normalizePSExtensionPath(directChild.pathString))
+    assertEquals(moduleBase.pathString, PSLanguageHostUtils.getPSExtensionModulesDir(manifest.pathString))
+    assertEquals(startupScript.pathString, PSLanguageHostUtils.getEditorServicesStartupScript(directChild.pathString))
+  }
+
+  @Test
+  fun testNormalizePSExtensionPathLeavesInvalidBoundariesUnchanged(@TempDir tempDir: Path) {
+    val missing = tempDir / "missing"
+    val unrelatedFile = (tempDir / "unrelated.txt").createFile()
+    val moduleDirectory = (tempDir / "PowerShellEditorServices").createDirectories()
+    (moduleDirectory / "PowerShellEditorServices.psd1").createFile()
+    val nestedDirectory = (moduleDirectory / "nested").createDirectories()
+    val nestedFile = (nestedDirectory / "nested.ps1").createFile()
+
+    listOf("", " ", missing.pathString, unrelatedFile.pathString, nestedDirectory.pathString, nestedFile.pathString).forEach {
+      assertEquals(it, PSLanguageHostUtils.normalizePSExtensionPath(it))
+    }
+  }
 
   @Test
   fun testBundledEditorServicesModulesArePresent() {


### PR DESCRIPTION
## What does this PR do?

Makes custom PowerShell Editor Services selection accept the module base, the `PowerShellEditorServices` module directory, or any file directly inside that module directory.

Selections are normalized to the existing module-base representation before settings are persisted, while the runtime path helpers normalize defensively as well. Existing extension-root installations continue to work unchanged.

## Related issue

Closes #285

## How was this tested?

- 5 focused `PSLanguageHostUtilsTests` covering accepted locations, legacy formats, runtime path resolution, and invalid boundaries
- `./gradlew build` compilation, searchable options, assembly, and packaging; aggregate tests retain the documented missing-PowerShell/PSES host limitation
- `git diff --check`
