### PR TITLE
CI: allow content write in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: write
+
     runs-on: ubuntu-24.04
     steps:
       - name: Free disk space


### PR DESCRIPTION
This workflow needs content write access to create a GitHub release. Otherwise, it fails due to missing permissions.