### PR TITLE
feat: add PowerShell module file action

### DIFF
--- a/src/main/kotlin/com/intellij/plugin/powershell/ide/actions/NewPowerShellModuleFileAction.kt
+++ b/src/main/kotlin/com/intellij/plugin/powershell/ide/actions/NewPowerShellModuleFileAction.kt
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package com.intellij.plugin.powershell.ide.actions
+
+import com.intellij.ide.actions.CreateFileFromTemplateAction
+import com.intellij.ide.actions.CreateFileFromTemplateDialog
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.plugin.powershell.PowerShellIcons
+import com.intellij.psi.PsiDirectory
+
+class NewPowerShellModuleFileAction : CreateFileFromTemplateAction("PowerShell module",
+                                                                   "Creates a PowerShell module file from template",
+                                                                   PowerShellIcons.FILE), DumbAware {
+  override fun getActionName(directory: PsiDirectory?, newName: String, templateName: String?): String = "New PowerShell module $newName"
+
+  override fun buildDialog(project: Project, directory: PsiDirectory, builder: CreateFileFromTemplateDialog.Builder) {
+    builder.setTitle("New PowerShell module")?.addKind("PowerShell module", PowerShellIcons.FILE, "PowerShell Module.psm1")
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -135,5 +135,8 @@
     <action id="NewPowerShellFile" class="com.intellij.plugin.powershell.ide.actions.NewPowerShellFileAction">
       <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFromTemplate"/>
     </action>
+    <action id="NewPowerShellModuleFile" class="com.intellij.plugin.powershell.ide.actions.NewPowerShellModuleFileAction">
+      <add-to-group group-id="NewGroup" anchor="after" relative-to-action="NewPowerShellFile"/>
+    </action>
   </actions>
 </idea-plugin>

--- a/src/test/kotlin/com/intellij/plugin/powershell/ide/actions/NewPowerShellModuleFileActionTest.kt
+++ b/src/test/kotlin/com/intellij/plugin/powershell/ide/actions/NewPowerShellModuleFileActionTest.kt
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 intellij-powershell contributors <https://github.com/intellij-powershell/intellij-powershell>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package com.intellij.plugin.powershell.ide.actions
+
+import com.intellij.ide.fileTemplates.FileTemplateManager
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.plugin.powershell.testFramework.PowerShellTestBase
+import com.intellij.testFramework.junit5.TestApplication
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+
+@TestApplication
+class NewPowerShellModuleFileActionTest : PowerShellTestBase() {
+  @Test
+  fun testActionAndTemplateAreRegistered() {
+    val action = ActionManager.getInstance().getAction("NewPowerShellModuleFile")
+    assertInstanceOf(NewPowerShellModuleFileAction::class.java, action)
+    assertEquals("PowerShell module", action.templatePresentation.text)
+
+    val template = FileTemplateManager.getInstance(project).getInternalTemplate("PowerShell Module.psm1")
+    assertEquals("", template.text)
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds a dedicated **New → PowerShell module** action that creates an empty `.psm1` module file from an internal template.

The new entry appears immediately after the existing PowerShell script action and uses the same PowerShell file icon and IntelliJ file-template workflow.

## Related issue

Closes #91

## How was this tested?

- Focused platform test for action registration, visible text, and `.psm1` template discovery
- `./gradlew build` compilation, searchable options, packaging, and assembly; aggregate tests retain the documented missing-PowerShell/PSES host limitation
- `git diff --check`
- Plugin XML validation with `xmllint`
